### PR TITLE
Fix small mistake in rust client

### DIFF
--- a/clients/rust/src/my_strategy.rs
+++ b/clients/rust/src/my_strategy.rs
@@ -72,7 +72,7 @@ impl MyStrategy {
         }
         model::UnitAction {
             velocity: target_pos.x - unit.position.x,
-            jump: target_pos.y > unit.position.y,
+            jump,
             jump_down: target_pos.y < unit.position.y,
             aim,
             shoot: true,


### PR DESCRIPTION
Jump variable was calculated but never used

Other clients use it.